### PR TITLE
Bump run-script to 0.1.0-beta.139

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "run-script": {
-      "version": "0.1.0",
+      "version": "0.1.0-beta.139",
       "commands": [
         "r"
       ]


### PR DESCRIPTION
This version contains the argument escaping fixes as well as forced color output.