### PR TITLE
Fix force color check

### DIFF
--- a/src/ConsoleHelpers.cs
+++ b/src/ConsoleHelpers.cs
@@ -14,15 +14,18 @@ internal static class ConsoleHelpers
             SupportsAnsiCodes = ConsoleFormatInfo.CurrentInfo.SupportsAnsiCodes,
         };
 
-        if (consoleFormatProvider.SupportsAnsiCodes)
+        if (environment.GetEnvironmentVariable("NO_COLOR") is not null)
         {
-            consoleFormatProvider.SupportsAnsiCodes = environment.GetEnvironmentVariable("NO_COLOR") is null;
-        }
-        else
-        {
-            var envVar = environment.GetEnvironmentVariable("DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION");
+            consoleFormatProvider.SupportsAnsiCodes = false;
 
-            consoleFormatProvider.SupportsAnsiCodes = envVar is not null && (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase));
+            return consoleFormatProvider;
+        }
+
+        var envVar = environment.GetEnvironmentVariable("DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION");
+
+        if (envVar is not null)
+        {
+            consoleFormatProvider.SupportsAnsiCodes = envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
 
         return consoleFormatProvider;

--- a/test/ConsoleHelpersTests.cs
+++ b/test/ConsoleHelpersTests.cs
@@ -16,7 +16,7 @@ public class ConsoleHelpersTests
     public void FormatInfoBuilder_should_support_NO_COLOR_env_var(string value)
     {
         // Given
-        var environment = new TestEnvironment(isWindows: true);
+        var environment = new TestEnvironment();
 
         environment.SetEnvironmentVariable("NO_COLOR", value);
 
@@ -41,7 +41,7 @@ public class ConsoleHelpersTests
     public void FormatInfoBuilder_should_support_DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION_env_var(string value, bool expected)
     {
         // Given
-        var environment = new TestEnvironment(isWindows: true);
+        var environment = new TestEnvironment();
 
         environment.SetEnvironmentVariable("DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION", value);
 

--- a/test/TestEnvironment.cs
+++ b/test/TestEnvironment.cs
@@ -1,15 +1,16 @@
 namespace RunScript;
 
 using System.Collections;
+using System.Runtime.InteropServices;
 
 internal class TestEnvironment : IEnvironment
 {
     private readonly Dictionary<string, string?> _variables = new(StringComparer.OrdinalIgnoreCase);
 
-    public TestEnvironment(bool isWindows)
+    public TestEnvironment(bool? isWindows = null)
     {
         CurrentDirectory = AttributeReader.GetProjectDirectory(GetType().Assembly);
-        IsWindows = isWindows;
+        IsWindows = isWindows ?? RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     }
 
     public string CurrentDirectory { get; }


### PR DESCRIPTION
The original logic passed on each platform, but failed on WSL. These changes look more correct and gets the desired results on all platforms and WSL.