### PR TITLE
Remove caret escaping from cmd commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,8 @@ jobs:
           name: integration-test-results
           path: ./.coverage/*.trx
 
+      - run: dotnet r integration:ci --verbose -- --logger "trx;LogFilePrefix=ci test"
+
   release:
     if: github.event_name == 'push'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- fixed: Don't escape the script passed to `cmd.exe`, just the double dash arguments
+
 ## [0.2.0](https://github.com/xt0rted/dotnet-run-script/compare/v0.1.0...v0.2.0) - 2022-04-23
+
+> ℹ️ This version broke conditional script execution (`cmd1 && cmd2`) in `cmd.exe`
 
 - added: Force color output with the `DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION` environment variable.
   - Note: this tool with output color on all platforms including when output is redirected, but the dotnet cli only supports this on Unix platforms currently. This means script results might not be colored in places like GitHub Actions build logs when using the Windows VMs.

--- a/global.json
+++ b/global.json
@@ -19,6 +19,9 @@
     "test:release": "dotnet r test -- --configuration Release",
     "pack:release": "dotnet r pack -- --configuration Release",
 
+    // integration tests
+    "integration:ci": "dotnet r clean && dotnet r clean:bin && dotnet build && dotnet test --no-build",
+
     // test scripts
     "info": "dotnet r dotnet:version && dotnet r dotnet:info",
     "dotnet:info": "dotnet --info",

--- a/src/ArgumentBuilder.cs
+++ b/src/ArgumentBuilder.cs
@@ -62,7 +62,7 @@ internal static class ArgumentBuilder
     {
         var sb = new ValueStringBuilder(stackalloc char[256]);
 
-        EscapeArgForCmd(ref sb, command, quoteValue: false);
+        sb.Append(command);
 
         if (args is not null)
         {
@@ -71,7 +71,7 @@ internal static class ArgumentBuilder
                 sb.Append(Caret);
                 sb.Append(Space);
 
-                EscapeArgForCmd(ref sb, args[i], quoteValue: true);
+                EscapeArgForCmd(ref sb, args[i]);
             }
         }
 
@@ -165,10 +165,9 @@ internal static class ArgumentBuilder
     /// </remarks>
     /// <param name="sb">The <seealso cref="ValueStringBuilder"/> to append to.</param>
     /// <param name="argument">The argument to escape.</param>
-    /// <param name="quoteValue">If the value should be wrapped in quotes if it contains whitespace.</param>
-    private static void EscapeArgForCmd(ref ValueStringBuilder sb, ReadOnlySpan<char> argument, bool quoteValue)
+    private static void EscapeArgForCmd(ref ValueStringBuilder sb, ReadOnlySpan<char> argument)
     {
-        var quoted = quoteValue && ArgumentContainsWhitespace(argument);
+        var quoted = ArgumentContainsWhitespace(argument);
 
         if (quoted)
         {

--- a/test/ArgumentBuilderTests.cs
+++ b/test/ArgumentBuilderTests.cs
@@ -27,19 +27,19 @@ public class ArgumentBuilderTests
     }
 
     [Theory]
-    [InlineData("cmd", null, "^c^m^d")]
-    [InlineData("cm \"d\"", null, "^c^m^ ^\"^d^\"")]
-    [InlineData("c m d", null, "^c^ ^m^ ^d")]
-    [InlineData("c m d", new string[0], "^c^ ^m^ ^d")]
-    [InlineData("c m d", new[] { "one", "two", "three" }, "^c^ ^m^ ^d^ ^o^n^e^ ^t^w^o^ ^t^h^r^e^e")]
-    [InlineData("c m d", new[] { "line1\nline2", "word1\tword2" }, "^c^ ^m^ ^d^ ^\"^l^i^n^e^1^\n^l^i^n^e^2^\"^ ^\"^w^o^r^d^1^\t^w^o^r^d^2^\"")]
-    [InlineData("c m d", new[] { "with spaces" }, "^c^ ^m^ ^d^ ^\"^w^i^t^h^ ^s^p^a^c^e^s^\"")]
-    [InlineData("c m d", new[] { @"with\backslash" }, @"^c^ ^m^ ^d^ ^w^i^t^h^\^b^a^c^k^s^l^a^s^h")]
-    [InlineData("c m d", new[] { @"""quotedwith\backslash""" }, @"^c^ ^m^ ^d^ ^""^q^u^o^t^e^d^w^i^t^h^\^b^a^c^k^s^l^a^s^h^""")]
-    [InlineData("c m d", new[] { @"C:\Users\" }, @"^c^ ^m^ ^d^ ^C^:^\^U^s^e^r^s^\")]
-    [InlineData("c m d", new[] { @"C:\Program Files\dotnet\" }, @"^c^ ^m^ ^d^ ^""^C^:^\^P^r^o^g^r^a^m^ ^F^i^l^e^s^\^d^o^t^n^e^t^\^""")]
-    [InlineData("c m d", new[] { @"backslash\""preceedingquote" }, @"^c^ ^m^ ^d^ ^b^a^c^k^s^l^a^s^h^\^""^p^r^e^c^e^e^d^i^n^g^q^u^o^t^e")]
-    [InlineData("c m d", new[] { @""" hello """ }, @"^c^ ^m^ ^d^ ^""^""^ ^h^e^l^l^o^ ^""^""")]
+    [InlineData("cmd", null, "cmd")]
+    [InlineData("cm \"d\"", null, "cm \"d\"")]
+    [InlineData("c m d", null, "c m d")]
+    [InlineData("c m d", new string[0], "c m d")]
+    [InlineData("c m d", new[] { "one", "two", "three" }, "c m d^ ^o^n^e^ ^t^w^o^ ^t^h^r^e^e")]
+    [InlineData("c m d", new[] { "line1\nline2", "word1\tword2" }, "c m d^ ^\"^l^i^n^e^1^\n^l^i^n^e^2^\"^ ^\"^w^o^r^d^1^\t^w^o^r^d^2^\"")]
+    [InlineData("c m d", new[] { "with spaces" }, "c m d^ ^\"^w^i^t^h^ ^s^p^a^c^e^s^\"")]
+    [InlineData("c m d", new[] { @"with\backslash" }, @"c m d^ ^w^i^t^h^\^b^a^c^k^s^l^a^s^h")]
+    [InlineData("c m d", new[] { @"""quotedwith\backslash""" }, @"c m d^ ^""^q^u^o^t^e^d^w^i^t^h^\^b^a^c^k^s^l^a^s^h^""")]
+    [InlineData("c m d", new[] { @"C:\Users\" }, @"c m d^ ^C^:^\^U^s^e^r^s^\")]
+    [InlineData("c m d", new[] { @"C:\Program Files\dotnet\" }, @"c m d^ ^""^C^:^\^P^r^o^g^r^a^m^ ^F^i^l^e^s^\^d^o^t^n^e^t^\^""")]
+    [InlineData("c m d", new[] { @"backslash\""preceedingquote" }, @"c m d^ ^b^a^c^k^s^l^a^s^h^\^""^p^r^e^c^e^e^d^i^n^g^q^u^o^t^e")]
+    [InlineData("c m d", new[] { @""" hello """ }, @"c m d^ ^""^""^ ^h^e^l^l^o^ ^""^""")]
     public void EscapeAndConcatenateCommandAndArgArrayForCmdProcessStart(string command, string[] args, string expected)
     {
         // Given / When


### PR DESCRIPTION
The change in #17 looks to have fixed the issues with `pwsh` and `bash`, as well as some minor issues with `cmd.exe`, but when a script like `dotnet --version && dotnet --info` is run in `cmd.exe` only the left portion executes. The escaped `^&^&` is acting as a terminator.

Based on what I've read, and the code in the dotnet sdk, escaping everything is the right way to do this. But based on real world testing the command portion doesn't need escaping, and doing so breaks some things. The additional arguments passed with the double dash still need this level of escaping but I'm sure another edge case will come up after merging this.