### PR TITLE
Drop .net 5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+> **Note**
+> This version drops support for .NET 5 which is no longer supported, but it will continue to work with .NET 5 SDKs.
+
 ### Added
 
 - Ability to run multiple scripts in a single call (e.g. `dotnet r build test pack`) ([#10](https://github.com/xt0rted/dotnet-run-script/pull/10))

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/global.json
+++ b/global.json
@@ -11,7 +11,6 @@
     "build": "dotnet build",
     "test": "dotnet test --no-build --logger \"trx;LogFilePrefix=tests\" --results-directory \"./coverage\"",
     "test:31": "dotnet r test -- --framework netcoreapp3.1",
-    "test:5": "dotnet r test -- --framework net5.0",
     "test:6": "dotnet r test -- --framework net6.0",
 
     "testbase": "dotnet test --no-build --logger \"trx;LogFilePrefix=tests\" --results-directory \"./coverage\"",


### PR DESCRIPTION
Since .net 5 is no longer supported there's no reason to keep supporting it here. If you're using a .net 5 sdk then the .net core 3.1 version will be used so any project targeting .net core 3.1+ will continue to work with this.