### PR TITLE
Support for globbing in script names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Added
 
 - Ability to run multiple scripts in a single call (e.g. `dotnet r build test pack`) ([#10](https://github.com/xt0rted/dotnet-run-script/pull/10))
+- Support for globbing in script names (e.g `dotnet r test:*` will match `test:unit` and `test:integration`) ([#79](https://github.com/xt0rted/dotnet-run-script/pull/79))
 
 ### Updated
 
@@ -22,7 +23,8 @@
 
 ## [0.2.0](https://github.com/xt0rted/dotnet-run-script/compare/v0.1.0...v0.2.0) - 2022-04-23
 
-> ℹ️ This version broke conditional script execution (`cmd1 && cmd2`) in `cmd.exe`
+> **Note**
+> This version broke conditional script execution (`cmd1 && cmd2`) in `cmd.exe`
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ In this example both the `--configuration` and `--framework` options will be pas
 dotnet r build test:unit test:integration package -- --configuration Release --framework net6.0
 ```
 
+### Globbing or wildcard support
+
+Multiple scripts can be run at the same time using globbing.
+This means `dotnet r test:*` will match `test:unit` and `test:integration` and run them in series in the order they're listed in the `global.json` file.
+
+Globbing is handled by the [DotNet.Glob](https://github.com/dazinator/DotNet.Glob) library and currently supports all of its patterns and wildcards.
+
 ### Working directory
 
 The working directory is set to the root of the project where the `global.json` is located.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ dotnet new tool-manifest
 dotnet tool install run-script
 ```
 
-> ⚠️ It's not recommended to install this tool globally.
+> **Warning**
+> Installing this tool globally is not recommended.
 > PowerShell defines the alias `r` for the `Invoke-History` command which prevents this from being called.
 > You'll also run into issues calling this from your scripts since global tools don't use the `dotnet` prefix.
 
@@ -79,9 +80,10 @@ In your project's `global.json` add a `scripts` object:
 }
 ```
 
-ℹ️ The shell used depends on the OS.
-On Windows `CMD` is used, on Linux, macOS, and WSL `sh` is used.
-This can be overridden by setting the `scriptShell` property or by passing the `--script-shell` option with the name of the shell to use.
+> **Note**
+> The shell used depends on the OS.
+> On Windows `CMD` is used, on Linux, macOS, and WSL `sh` is used.
+> This can be overridden by setting the `scriptShell` property or by passing the `--script-shell` option with the name of the shell to use.
 
 The `env` command is a special built-in command that lists all available environment variables.
 You can override this with your own command if you wish.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "name": "dotnet-run-script",
-      "license": "ISC",
       "devDependencies": {
         "markdownlint-cli": "^0.32.1"
       }

--- a/src/Polyfills/IsExternalInit.cs
+++ b/src/Polyfills/IsExternalInit.cs
@@ -1,0 +1,15 @@
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    using System.ComponentModel;
+
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}
+#endif

--- a/src/Polyfills/TaskExtensions.cs
+++ b/src/Polyfills/TaskExtensions.cs
@@ -5,7 +5,7 @@ namespace RunScript;
 
 using System.Diagnostics;
 
-internal static class Polyfills
+internal static class TaskExtensions
 {
 #if !NET5_0_OR_GREATER
     public static async Task WaitForExitAsync(this Process process, CancellationToken cancellationToken)

--- a/src/RunResult.cs
+++ b/src/RunResult.cs
@@ -1,0 +1,3 @@
+namespace RunScript;
+
+internal record RunResult(string Name, int ExitCode);

--- a/src/ScriptResult.cs
+++ b/src/ScriptResult.cs
@@ -1,0 +1,3 @@
+namespace RunScript;
+
+internal record ScriptResult(string Name, bool Exists);

--- a/src/run-script.csproj
+++ b/src/run-script.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNet.Glob" Version="3.1.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/test/RunScriptCommandTests.RunResults.Should_handle_any_error_result_exitCode=1.verified.txt
+++ b/test/RunScriptCommandTests.RunResults.Should_handle_any_error_result_exitCode=1.verified.txt
@@ -1,0 +1,8 @@
+﻿{
+  IsErrorRedirected: false,
+  IsInputRedirected: false,
+  IsOutputRedirected: false,
+  Out:
+ERROR: "test" exited with 1
+
+}

--- a/test/RunScriptCommandTests.RunResults.Should_handle_any_error_result_exitCode=13.verified.txt
+++ b/test/RunScriptCommandTests.RunResults.Should_handle_any_error_result_exitCode=13.verified.txt
@@ -1,0 +1,8 @@
+﻿{
+  IsErrorRedirected: false,
+  IsInputRedirected: false,
+  IsOutputRedirected: false,
+  Out:
+ERROR: "test" exited with 13
+
+}

--- a/test/RunScriptCommandTests.RunResults.Should_handle_multiple_error_results.verified.txt
+++ b/test/RunScriptCommandTests.RunResults.Should_handle_multiple_error_results.verified.txt
@@ -1,0 +1,9 @@
+﻿{
+  IsErrorRedirected: false,
+  IsInputRedirected: false,
+  IsOutputRedirected: false,
+  Out:
+ERROR: "build" exited with 13
+ERROR: "test" exited with 99
+
+}

--- a/test/RunScriptCommandTests.RunResults.Should_handle_multiple_success_results.verified.txt
+++ b/test/RunScriptCommandTests.RunResults.Should_handle_multiple_success_results.verified.txt
@@ -1,0 +1,5 @@
+﻿{
+  IsErrorRedirected: false,
+  IsInputRedirected: false,
+  IsOutputRedirected: false
+}

--- a/test/RunScriptCommandTests.RunResults.Should_handle_single_result_exitCode=0.verified.txt
+++ b/test/RunScriptCommandTests.RunResults.Should_handle_single_result_exitCode=0.verified.txt
@@ -1,0 +1,5 @@
+﻿{
+  IsErrorRedirected: false,
+  IsInputRedirected: false,
+  IsOutputRedirected: false
+}

--- a/test/RunScriptCommandTests.RunResults.Should_handle_single_result_exitCode=1.verified.txt
+++ b/test/RunScriptCommandTests.RunResults.Should_handle_single_result_exitCode=1.verified.txt
@@ -1,0 +1,5 @@
+﻿{
+  IsErrorRedirected: false,
+  IsInputRedirected: false,
+  IsOutputRedirected: false
+}

--- a/test/RunScriptCommandTests.RunResults.Should_handle_single_result_exitCode=13.verified.txt
+++ b/test/RunScriptCommandTests.RunResults.Should_handle_single_result_exitCode=13.verified.txt
@@ -1,0 +1,5 @@
+﻿{
+  IsErrorRedirected: false,
+  IsInputRedirected: false,
+  IsOutputRedirected: false
+}

--- a/test/RunScriptCommandTests.cs
+++ b/test/RunScriptCommandTests.cs
@@ -1,0 +1,191 @@
+namespace RunScript;
+
+using System.Collections.Generic;
+using System.CommandLine.IO;
+using System.CommandLine.Rendering;
+
+public static class RunScriptCommandTests
+{
+    [Trait("category", "unit")]
+    public class FindScripts
+    {
+        private readonly Dictionary<string, string?> _projectScripts;
+
+        public FindScripts()
+        {
+            _projectScripts = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "clean", "echo clean" },
+                { "prebuild", "echo prebuild" },
+                { "build", "echo build" },
+                { "test", "echo test" },
+                { "posttest", "echo posttest" },
+                { "prepack", "echo pack" },
+                { "pack", "echo pack" },
+                { "postpack", "echo pack" },
+            };
+        }
+
+        [Fact]
+        public void Should_match_exact_script_names()
+        {
+            // Given
+            var scripts = new[]
+            {
+                "build",
+                "test",
+                "magic",
+            };
+
+            // When
+            var result = RunScriptCommand.FindScripts(
+                _projectScripts,
+                scripts);
+
+            // Then
+            result.ShouldBe(
+                new List<ScriptResult>
+                {
+                    new("build", true),
+                    new("test", true),
+                    new("magic", false),
+                });
+        }
+
+        [Fact]
+        public void Should_match_wildcard_script_names()
+        {
+            // Given
+            var scripts = new[]
+            {
+                "pre*",
+                "magic*",
+            };
+
+            // When
+            var result = RunScriptCommand.FindScripts(
+                _projectScripts,
+                scripts);
+
+            // Then
+            result.ShouldBe(
+                new List<ScriptResult>
+                {
+                    new("prebuild", true),
+                    new("prepack", true),
+                    new("magic*", false),
+                });
+        }
+    }
+
+    [Trait("category", "unit")]
+    [UsesVerify]
+    public class RunResults
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(13)]
+        public async Task Should_handle_single_result(int exitCode)
+        {
+            // Given
+            var (console, writer) = SetUpTest();
+            var results = new List<RunResult>
+            {
+                new("build", exitCode),
+            };
+
+            // When
+            var result = RunScriptCommand.RunResults(
+                writer,
+                results);
+
+            // Then
+            result.ShouldBe(exitCode);
+
+            await Verify(console).UseParameters(exitCode);
+        }
+
+        [Fact]
+        public async Task Should_handle_multiple_success_results()
+        {
+            // Given
+            var (console, writer) = SetUpTest();
+            var results = new List<RunResult>
+            {
+                new("build", 0),
+                new("test", 0),
+            };
+
+            // When
+            var result = RunScriptCommand.RunResults(
+                writer,
+                results);
+
+            // Then
+            result.ShouldBe(0);
+
+            await Verify(console);
+        }
+
+        [Fact]
+        public async Task Should_handle_multiple_error_results()
+        {
+            // Given
+            var (console, writer) = SetUpTest();
+            var results = new List<RunResult>
+            {
+                new("build", 13),
+                new("test", 99),
+            };
+
+            // When
+            var result = RunScriptCommand.RunResults(
+                writer,
+                results);
+
+            // Then
+            result.ShouldBe(1);
+
+            await Verify(console);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(13)]
+        public async Task Should_handle_any_error_result(int exitCode)
+        {
+            // Given
+            var (console, writer) = SetUpTest();
+            var results = new List<RunResult>
+            {
+                new("build", 0),
+                new("test", exitCode),
+            };
+
+            // When
+            var result = RunScriptCommand.RunResults(
+                writer,
+                results);
+
+            // Then
+            result.ShouldBe(1);
+
+            await Verify(console).UseParameters(exitCode);
+        }
+
+        private static (TestConsole console, IConsoleWriter writer) SetUpTest()
+        {
+            var console = new TestConsole();
+            var consoleWriter = new ConsoleWriter(
+                console,
+                new ConsoleFormatInfo
+                {
+                    SupportsAnsiCodes = false,
+                },
+                verbose: true);
+
+            return (console, consoleWriter);
+        }
+    }
+}


### PR DESCRIPTION
This lets you run multiple scripts in series using wildcards. This means `test:*` will match `test:unit` and `test:integration` and run them in series in the order they're listed in the `global.json` file.

Globbing is handled by the [DotNet.Glob](https://github.com/dazinator/DotNet.Glob) library and supports all of its patterns and wildcards. This may need to change based on user feedback and performance.

Working on this made me realize there's a lot of code to make script names case insensitive while `npm` is case sensitive. To simplify things and reduce the possibility of bugs we should probably do the same.