### PR TITLE
Add github actions log groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- A new environment variable called `DOTNET_R_CHILDPROCESS` which is set to `true` when executing a script. Use this to check if you're running inside `dotnet r` or not.
+- Support for [GitHub Actions log groups](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines)
+
 ## [0.4.0](https://github.com/xt0rted/dotnet-run-script/compare/v0.3.0...v0.4.0) - 2022-08-12
 
 > **Note**

--- a/src/CommandRunner.cs
+++ b/src/CommandRunner.cs
@@ -32,6 +32,8 @@ internal class CommandRunner : ICommandRunner
             process.StartInfo.WorkingDirectory = _processContext.WorkingDirectory;
             process.StartInfo.FileName = _processContext.Shell;
 
+            process.StartInfo.Environment[EnvironmentVariables.RunScriptChildProcess] = "true";
+
             var outStream = new StreamForwarder();
             var errStream = new StreamForwarder();
             Task? taskOut = null;

--- a/src/EnvironmentVariables.cs
+++ b/src/EnvironmentVariables.cs
@@ -1,0 +1,8 @@
+﻿namespace RunScript;
+
+internal static class EnvironmentVariables
+{
+    public static string GitHubActions => "GITHUB_ACTIONS";
+
+    public static string RunScriptChildProcess => "DOTNET_R_CHILDPROCESS";
+}

--- a/src/Logging/GitHubActionsLogGroup.cs
+++ b/src/Logging/GitHubActionsLogGroup.cs
@@ -1,0 +1,22 @@
+namespace RunScript.Logging;
+
+internal sealed class GitHubActionsLogGroup : IDisposable
+{
+    private readonly IConsoleWriter _writer;
+
+    public GitHubActionsLogGroup(IConsoleWriter writer, string name)
+    {
+        _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+
+        _writer.Raw("::group::" + EscapeData("dotnet r " + name) + Environment.NewLine);
+    }
+
+    public void Dispose()
+        => _writer.Raw("::endgroup::" + Environment.NewLine);
+
+    private static string EscapeData(string value)
+        => value
+            .Replace("%", "%25", StringComparison.OrdinalIgnoreCase)
+            .Replace("\r", "%0D", StringComparison.OrdinalIgnoreCase)
+            .Replace("\n", "%0A", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Logging/IConsoleWriterExtensions.cs
+++ b/src/Logging/IConsoleWriterExtensions.cs
@@ -1,0 +1,21 @@
+namespace RunScript.Logging;
+
+internal static class IConsoleWriterExtensions
+{
+    public static IDisposable Group(this IConsoleWriter writer, IEnvironment environment, string name)
+    {
+        var isRunningOnActions = string.Equals(
+            environment.GetEnvironmentVariable(EnvironmentVariables.GitHubActions),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+
+        var isChildProcess = string.Equals(
+            environment.GetEnvironmentVariable(EnvironmentVariables.RunScriptChildProcess),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+
+        return isRunningOnActions && !isChildProcess
+            ? new GitHubActionsLogGroup(writer, name)
+            : new SilentLogGroup();
+    }
+}

--- a/src/Logging/SilentLogGroup.cs
+++ b/src/Logging/SilentLogGroup.cs
@@ -1,0 +1,8 @@
+﻿namespace RunScript.Logging;
+
+internal sealed class SilentLogGroup : IDisposable
+{
+    public void Dispose()
+    {
+    }
+}

--- a/test/Logging/GitHubActionsLogGroupTests.Should_escape_group_name.verified.txt
+++ b/test/Logging/GitHubActionsLogGroupTests.Should_escape_group_name.verified.txt
@@ -1,0 +1,17 @@
+﻿{
+  IsErrorRedirected: false,
+  IsInputRedirected: false,
+  IsOutputRedirected: false,
+  Out:
+::group::dotnet r plain
+::endgroup::
+::group::dotnet r percent: %2525
+::endgroup::
+::group::dotnet r carriage return: %0D
+::endgroup::
+::group::dotnet r line feed: %0A
+::endgroup::
+::group::dotnet r everything: %25%0D%0A
+::endgroup::
+
+}

--- a/test/Logging/GitHubActionsLogGroupTests.cs
+++ b/test/Logging/GitHubActionsLogGroupTests.cs
@@ -1,0 +1,36 @@
+namespace RunScript.Logging;
+
+using System.CommandLine.IO;
+using System.CommandLine.Rendering;
+
+[Trait("category", "unit")]
+[UsesVerify]
+public class GitHubActionsLogGroupTests
+{
+    [Fact]
+    public async Task Should_escape_group_name()
+    {
+        // Given
+        var console = new TestConsole();
+        var consoleFormatProvider = new ConsoleFormatInfo
+        {
+            SupportsAnsiCodes = false,
+        };
+        var consoleWriter = new ConsoleWriter(console, consoleFormatProvider, verbose: false);
+
+        // When
+        createGroup("plain");
+        createGroup("percent: %25");
+        createGroup("carriage return: \r");
+        createGroup("line feed: \n");
+        createGroup("everything: %\r\n");
+
+        // Then
+        await Verify(console);
+
+        void createGroup(string groupName)
+        {
+            using var _ = new GitHubActionsLogGroup(consoleWriter, groupName);
+        }
+    }
+}


### PR DESCRIPTION
Adds a new env var that lets us check if we're running inside ourself, and writes out GitHub Actions log group commands for the top level call only (they can't be nested 😞). This should give a more tidy build log and help you search the results more easily. Examples of this can be seen in the integration test results.

<img width="340" alt="image" src="https://user-images.githubusercontent.com/831974/188329276-e26da131-515a-4d10-8bf8-39d117d44f9a.png">
