### PR TITLE
Treat colon as a path separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Adjusted globbing so `:` acts like a path separator ([#131](https://github.com/xt0rted/dotnet-run-script/pull/131))
+  - `foo:*` will match `foo:bar` but not `foo:bar:baz`
+  - `foo:*:baz` will match `foo:bar:baz`
+  - `foo:**` will match `foo:bar` and `foo:bar:baz`
+
 ## [0.5.0](https://github.com/xt0rted/dotnet-run-script/compare/v0.4.0...v0.5.0) - 2022-10-11
 
 ### Added

--- a/src/RunScriptCommand.cs
+++ b/src/RunScriptCommand.cs
@@ -151,7 +151,7 @@ internal class RunScriptCommand : RootCommand, ICommandHandler
 
             var hadMatch = false;
             var matcher = Glob.Parse(
-                script,
+                SwapColonAndSlash(script),
                 new GlobOptions
                 {
                     Evaluation =
@@ -162,7 +162,7 @@ internal class RunScriptCommand : RootCommand, ICommandHandler
 
             foreach (var projectScript in projectScripts.Keys)
             {
-                if (matcher.IsMatch(projectScript.AsSpan()))
+                if (matcher.IsMatch(SwapColonAndSlash(projectScript).AsSpan()))
                 {
                     hadMatch = true;
 
@@ -200,5 +200,28 @@ internal class RunScriptCommand : RootCommand, ICommandHandler
         }
 
         return hadError ? 1 : 0;
+    }
+
+    internal static string SwapColonAndSlash(string scriptName)
+    {
+        var result = new char[scriptName.Length];
+
+        for (var i = 0; i < scriptName.Length; i++)
+        {
+            if (scriptName[i] == ':')
+            {
+                result[i] = '/';
+            }
+            else if (scriptName[i] == '/')
+            {
+                result[i] = ':';
+            }
+            else
+            {
+                result[i] = scriptName[i];
+            }
+        }
+
+        return new string(result);
     }
 }

--- a/test/RunScriptCommandTests.cs
+++ b/test/RunScriptCommandTests.cs
@@ -23,6 +23,19 @@ public static class RunScriptCommandTests
                 { "prepack", "echo pack" },
                 { "pack", "echo pack" },
                 { "postpack", "echo pack" },
+                { "foo", "foo" },
+                { "foo:foo", "foo:foo" },
+                { "foo:bar", "foo:bar" },
+                { "foo:baz", "foo:baz" },
+                { "foo:foo:foo", "foo:foo:foo" },
+                { "foo:foo:bar", "foo:foo:bar" },
+                { "foo:foo:baz", "foo:foo:baz" },
+                { "foo:bar:foo", "foo:bar:foo" },
+                { "foo:bar:bar", "foo:bar:bar" },
+                { "foo:bar:baz", "foo:bar:baz" },
+                { "foo:baz:foo", "foo:baz:foo" },
+                { "foo:baz:bar", "foo:baz:bar" },
+                { "foo:baz:baz", "foo:baz:baz" },
             };
         }
 
@@ -58,6 +71,7 @@ public static class RunScriptCommandTests
             // Given
             var scripts = new[]
             {
+                "foo*",
                 "pre*",
                 "magic*",
             };
@@ -71,9 +85,91 @@ public static class RunScriptCommandTests
             result.ShouldBe(
                 new List<ScriptResult>
                 {
+                    new("foo", true),
                     new("prebuild", true),
                     new("prepack", true),
                     new("magic*", false),
+                });
+        }
+
+        [Fact]
+        public void Should_match_only_1_segment()
+        {
+            // Given
+            var scripts = new[]
+            {
+                "foo:*"
+            };
+
+            // When
+            var result = RunScriptCommand.FindScripts(
+                _projectScripts,
+                scripts);
+
+            // Then
+            result.ShouldBe(
+                new List<ScriptResult>
+                {
+                    new("foo:foo", true),
+                    new("foo:bar", true),
+                    new("foo:baz", true),
+                });
+        }
+
+        [Fact]
+        public void Should_match_only_1_trailing_segment()
+        {
+            // Given
+            var scripts = new[]
+            {
+                "foo:bar:*"
+            };
+
+            // When
+            var result = RunScriptCommand.FindScripts(
+                _projectScripts,
+                scripts);
+
+            // Then
+            result.ShouldBe(
+                new List<ScriptResult>
+                {
+                    new("foo:bar:foo", true),
+                    new("foo:bar:bar", true),
+                    new("foo:bar:baz", true),
+                });
+        }
+
+        [Fact]
+        public void Should_match_multiple_segments()
+        {
+            // Given
+            var scripts = new[]
+            {
+                "foo:**"
+            };
+
+            // When
+            var result = RunScriptCommand.FindScripts(
+                _projectScripts,
+                scripts);
+
+            // Then
+            result.ShouldBe(
+                new List<ScriptResult>
+                {
+                    new("foo:foo", true),
+                    new("foo:bar", true),
+                    new("foo:baz", true),
+                    new("foo:foo:foo", true),
+                    new("foo:foo:bar", true),
+                    new("foo:foo:baz", true),
+                    new("foo:bar:foo", true),
+                    new("foo:bar:bar", true),
+                    new("foo:bar:baz", true),
+                    new("foo:baz:foo", true),
+                    new("foo:baz:bar", true),
+                    new("foo:baz:baz", true),
                 });
         }
     }


### PR DESCRIPTION
This adjusts how globbing works with script names so `:` is treated as `/`. To do this we swap those two characters before comparing them which is also how `npm-run-all` does it.

Changing the behavior of `:` allows the following scenarios now:

1. `foo:*` will match `foo:bar` but not `foo:bar:baz`
2. `foo:*:baz` will match `foo:bar:baz`
3. `foo:**` will match `foo:bar` and `foo:bar:baz`
