### PR TITLE
Fix parameter forwarding for pwsh

### DIFF
--- a/src/ArgumentBuilder.cs
+++ b/src/ArgumentBuilder.cs
@@ -54,6 +54,35 @@ internal static class ArgumentBuilder
     /// Undo the processing which took place to create string[] args in Main, so that the next process will receive the same string[] args.
     /// </summary>
     /// <remarks>
+    /// Note that pwsh does not require any special escaping of arguments. We can simply concatenate the list of strings with a space between each.
+    /// </remarks>
+    /// <param name="command">The base command.</param>
+    /// <param name="args">List of arguments to escape.</param>
+    /// <returns>An escaped string of the <paramref name="command"/> and <paramref name="args"/>.</returns>
+    public static string ConcatenateCommandAndArgArrayForPwshProcessStart(
+        string? command,
+        string[]? args)
+    {
+        var sb = new ValueStringBuilder(stackalloc char[256]);
+
+        sb.Append(command);
+
+        if (args is not null)
+        {
+            for (var i = 0; i < args.Length; i++)
+            {
+                sb.Append(Space);
+                sb.Append(args[i]);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Undo the processing which took place to create string[] args in Main, so that the next process will receive the same string[] args.
+    /// </summary>
+    /// <remarks>
     /// See here for more info: <seealso href="https://docs.microsoft.com/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way"/>.
     /// </remarks>
     /// <param name="command">The base command.</param>

--- a/src/CommandRunner.cs
+++ b/src/CommandRunner.cs
@@ -56,6 +56,11 @@ internal class CommandRunner : ICommandRunner
                     ArgumentBuilder.EscapeAndConcatenateCommandAndArgArrayForCmdProcessStart(cmd, args),
                     "\"");
             }
+            else if (_processContext.Shell.Equals("pwsh", StringComparison.OrdinalIgnoreCase))
+            {
+                process.StartInfo.ArgumentList.Add("-c");
+                process.StartInfo.ArgumentList.Add(ArgumentBuilder.ConcatenateCommandAndArgArrayForPwshProcessStart(cmd, args));
+            }
             else
             {
                 process.StartInfo.ArgumentList.Add("-c");

--- a/test/ArgumentBuilderTests.cs
+++ b/test/ArgumentBuilderTests.cs
@@ -28,6 +28,29 @@ public class ArgumentBuilderTests
     }
 
     [Theory]
+    [InlineData("pwsh", null, "pwsh")]
+    [InlineData("pws \"h\"", null, "pws \"h\"")]
+    [InlineData("p w s h", null, "p w s h")]
+    [InlineData("pwsh", new string[0], "pwsh")]
+    [InlineData("pwsh", new[] { "one", "two", "three" }, "pwsh one two three")]
+    [InlineData("pwsh", new[] { "line1\nline2", "word1\tword2" }, "pwsh line1\nline2 word1\tword2")]
+    [InlineData("pwsh", new[] { "with spaces" }, "pwsh with spaces")]
+    [InlineData("pwsh", new[] { @"with\backslash" }, @"pwsh with\backslash")]
+    [InlineData("pwsh", new[] { @"""quotedwith\backslash""" }, @"pwsh ""quotedwith\backslash""" )]
+    [InlineData("pwsh", new[] { @"C:\Users\" }, @"pwsh C:\Users\")]
+    [InlineData("pwsh", new[] { @"C:\Program Files\dotnet\" }, @"pwsh C:\Program Files\dotnet\")]
+    [InlineData("pwsh", new[] { @"backslash\""preceedingquote" }, @"pwsh backslash\""preceedingquote")]
+    [InlineData("pwsh", new[] { @""" hello """ }, @"pwsh "" hello """)]
+    public void ConcatenateCommandAndArgArrayForPwshProcessStart(string command, string[]? args, string expected)
+    {
+        // Given / When
+        var result = ArgumentBuilder.ConcatenateCommandAndArgArrayForPwshProcessStart(command, args);
+
+        // Then
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
     [InlineData("cmd", null, "cmd")]
     [InlineData("cm \"d\"", null, "cm \"d\"")]
     [InlineData("c m d", null, "c m d")]


### PR DESCRIPTION
When using the pwsh script shell and trying to pass arguments after the double dash `--` to an underlying PowerShell script, it did not like having the arguments escaped. Instead, in the pwsh case, specifically, we just concatenate the arguments to pass to the underlying command.

Note that instead of modifying the existing branch for non-cmd shells in `CommandRunner.cs`, I added a specific check for `pwsh` to ensure this change does *not* affect other shells like bash/sh.

See issue #398 for more context and a repro of the bug.