### PR TITLE
Upgrade from .NET 8 to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Arguments passed after the double dash are passed through to each executing scri
 In this example both the `--configuration` and `--framework` options will be passed to each of the four scripts when running them.
 
 ```console
-dotnet r build test:unit test:integration package -- --configuration Release --framework net8.0
+dotnet r build test:unit test:integration package -- --configuration Release --framework net10.0
 ```
 
 ### Globbing or wildcard support

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.413"
+    "version": "10.0.300"
   },
   "scripts": {
     // project scripts


### PR DESCRIPTION
.NET 8 reaches end of support in November 2026. .NET 10 is the current LTS release.

## Changes
- `global.json`: SDK 8.0.413 → 10.0.300
- `Directory.Build.props`: TargetFramework `net8.0` → `net10.0`

All tests pass (123 passed, 1 skipped Unix-only test).